### PR TITLE
Use prettified URL for blog posts.

### DIFF
--- a/cactus/skeleton/plugins/blog.disabled.py
+++ b/cactus/skeleton/plugins/blog.disabled.py
@@ -50,7 +50,7 @@ def preBuild(site):
             postContext['title'] = find('title')
             postContext['author'] = find('author')
             postContext['date'] = find('date')
-            postContext['path'] = page.path
+            postContext['path'] = page.final_url
             postContext['body'] = getNode(get_template(page.path), name="body")
 
             # Parse the date into a date object

--- a/cactus/skeleton/plugins/blog.disabled.py
+++ b/cactus/skeleton/plugins/blog.disabled.py
@@ -81,7 +81,7 @@ def preBuildPage(site, page, context, data):
     context['posts'] = POSTS
 
     for post in POSTS:
-        if post['path'] == page.path:
+        if post['path'] == page.final_url:
             context.update(post)
 
     return context, data

--- a/cactus/tests/data/skeleton/plugins/blog.disabled.py
+++ b/cactus/tests/data/skeleton/plugins/blog.disabled.py
@@ -50,7 +50,7 @@ def preBuild(site):
             postContext['title'] = find('title')
             postContext['author'] = find('author')
             postContext['date'] = find('date')
-            postContext['path'] = page.path
+            postContext['path'] = page.final_url
             postContext['body'] = getNode(get_template(page.path), name="body")
 
             # Parse the date into a date object


### PR DESCRIPTION
When setting prettify_urls to True, Page.path is not the URL that the page is
uploaded to but the one where the source of the page is (including a possible
.html extension). Therefore this commit uses Page.final_url which does
not have the bogus .html extension when using prettified URLs.