### PR TITLE
Makes full template power available to blog posts.

### DIFF
--- a/cactus/skeleton/plugins/blog.disabled.py
+++ b/cactus/skeleton/plugins/blog.disabled.py
@@ -27,6 +27,7 @@ def getNode(template, context=Context(), name='subject'):
 def preBuild(site):
 
     global POSTS
+    siteContext = site.context();
 
     # Build all the posts
     for page in site.pages():
@@ -46,12 +47,16 @@ def preBuild(site):
                 return c.get(name, '')
 
             # Build a context for each post
+            context = {'__CACTUS_CURRENT_PAGE__': page,}
+            context.update(siteContext);
             postContext = {}
             postContext['title'] = find('title')
             postContext['author'] = find('author')
             postContext['date'] = find('date')
             postContext['path'] = page.final_url
-            postContext['body'] = getNode(get_template(page.path), name="body")
+            postContext['body'] = getNode(get_template(page.path),
+                                          context=Context(context),
+                                          name="body")
 
             # Parse the date into a date object
             try:

--- a/cactus/tests/data/skeleton/plugins/blog.disabled.py
+++ b/cactus/tests/data/skeleton/plugins/blog.disabled.py
@@ -27,6 +27,7 @@ def getNode(template, context=Context(), name='subject'):
 def preBuild(site):
 
     global POSTS
+    siteContext = site.context();
 
     # Build all the posts
     for page in site.pages():
@@ -46,12 +47,16 @@ def preBuild(site):
                 return c.get(name, '')
 
             # Build a context for each post
+            context = {'__CACTUS_CURRENT_PAGE__': page,}
+            context.update(siteContext);
             postContext = {}
             postContext['title'] = find('title')
             postContext['author'] = find('author')
             postContext['date'] = find('date')
             postContext['path'] = page.final_url
-            postContext['body'] = getNode(get_template(page.path), name="body")
+            postContext['body'] = getNode(get_template(page.path),
+                                          context=Context(context),
+                                          name="body")
 
             # Parse the date into a date object
             try:


### PR DESCRIPTION
Previously, I got weired errors when using e.g. `{% url path %}`
in blog posts:

```
*** Error while building
'__CACTUS_SITE__'
Traceback (most recent call last):
...
File "/usr/local/lib/python2.7/dist-packages/Cactus-3.3.2-py2.7.egg/cactus/template_tags.py", line 52, in url
    site = context['__CACTUS_SITE__']
  File "/usr/local/lib/python2.7/dist-packages/Django-1.6.11-py2.7.egg/django/template/context.py", line 56, in __getitem__
    raise KeyError(key)
KeyError: '__CACTUS_SITE__'
```

It turns out that `getNode` needs the full site context
to work probably.
Therefore this commit creates the site context and adds it to all postContexts.
Now I can use `{% url path %}` and the likes in my blog posts.