### PR TITLE
added gitcommitid plugin

### DIFF
--- a/cactus/skeleton/plugins/gitcommitid.disabled.py
+++ b/cactus/skeleton/plugins/gitcommitid.disabled.py
@@ -1,0 +1,24 @@
+import subprocess
+
+
+
+KEY = 'GIT_COMMITID'
+
+def commitid():
+    command = 'git log -1 --format="%H"'
+    print("run command [%s]" % command)
+    result = subprocess.check_output(command, shell=True)
+    result = result.rstrip('\n')
+    print("result command [%s]" % result)
+    return result
+
+
+mycommitid = "undefined"
+
+def preBuildPage(page, context, data):
+    global mycommitid
+    if (mycommitid == "undefined"):
+        mycommitid = commitid()
+
+    context[KEY] = mycommitid
+    return context, data


### PR DESCRIPTION
Hi!

This is a sweet little plugin that allows insertion of the (latest) git commit-id of your repository into pages and templates. Could save lives when debugging.

Thx
Lucas
