### PR TITLE
fixed #263: message:make creates 'e' and 'n' locale directories if locale is set to 'en'

### DIFF
--- a/cactus/cli.py
+++ b/cactus/cli.py
@@ -46,12 +46,12 @@ class CactusCli(object):
 
     def build(self, path, config):
         """Build a cactus project"""
-        site = self.Site(path, config)
+        site = self.Site(path, config, verb=self.Site.VERB_BUILD)
         site.build()
 
     def deploy(self, path, config):
         """Upload the project to S3"""
-        site = self.Site(path, config)
+        site = self.Site(path, config, verb=self.Site.VERB_DEPLOY)
         site.upload()
 
     def make_messages(self, path, config):
@@ -61,7 +61,7 @@ class CactusCli(object):
 
     def serve(self, path, config, port, browser):
         """Serve the project and watch changes"""
-        site = self.Site(path, config)
+        site = self.Site(path, config, verb=self.Site.VERB_SERVE)
         site.serve(port=port, browser=browser)
 
     def domain_setup(self, path, config):

--- a/cactus/i18n/commands.py
+++ b/cactus/i18n/commands.py
@@ -42,7 +42,7 @@ def WrappedCommandFactory(wrapped, default_kwargs=None):
             self.site = site
 
         def execute(self):
-            kwargs = {"locale": self.site.locale}
+            kwargs = {"locale": [self.site.locale]}
             kwargs.update(base_kwargs)
 
             cmd = wrapped()

--- a/cactus/site.py
+++ b/cactus/site.py
@@ -45,13 +45,19 @@ class Site(SiteCompatibilityLayer):
     _parallel = PARALLEL_CONSERVATIVE  #TODO: Test me
     _static = None
 
+    VERB_UNKNOWN = 0
+    VERB_SERVE = 1
+    VERB_BUILD = 2
+
     def __init__(self, path, config_paths=None, ui=None,
-        PluginManagerClass=None, ExternalManagerClass=None, DeploymentEngineClass=None):
+        PluginManagerClass=None, ExternalManagerClass=None, DeploymentEngineClass=None,
+        verb=VERB_UNKNOWN):
 
         # Load the config engine
         if config_paths is None:
             config_paths = []
         self.config = ConfigRouter(config_paths)
+        self.verb = verb
 
         # Load site-specific config values
         self.prettify_urls = self.config.get('prettify', False)
@@ -441,6 +447,7 @@ class Site(SiteCompatibilityLayer):
         """
         self._parallel = PARALLEL_DISABLED
         self._port = port
+        self.verb = self.VERB_SERVE
 
         self.clean()
         self.build()

--- a/cactus/template_tags.py
+++ b/cactus/template_tags.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 register = Library()
 
+
 def static(context, link_url):
     """
     Get the path for a static file in the Cactus build.
@@ -44,6 +45,7 @@ def static(context, link_url):
 
     return url
 
+
 def url(context, link_url):
     """
     Get the path for a page in the Cactus build.
@@ -65,10 +67,15 @@ def url(context, link_url):
 
         url = link_url
 
+    if site.verb == site.VERB_BUILD:
+        # prepend links with language directory
+        url = u"/%s%s" % (site.config.get("locale", "en-us"), url)
+
     if site.prettify_urls:
         return url.rsplit('index.html', 1)[0]
 
     return url
+
 
 def config(context, key):
     """


### PR DESCRIPTION
Besides, this also fixes MO file creation during 'build' and 'serve'